### PR TITLE
Avoid 301s for links on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,11 +54,11 @@
 		<h4 class="light">Alexander Beletsky's development blog</h4>
 		<h1><a href="/">My profession is engineering</a></h1>
 		<nav role="navigation" class="pure-menu pure-menu-open pure-menu-horizontal light"><ul>
-	<li><a href="/projects">Projects</a></li>
-	<li><a href="/talks">Talks</a></li>
-	<li><a href="/medium">Medium</a></li>
-	<li><a href="/blog/archives">Archive</a></li>
-	<li><a href="/about">About me</a></li>
+	<li><a href="/projects/">Projects</a></li>
+	<li><a href="/talks/">Talks</a></li>
+	<li><a href="/medium/">Medium</a></li>
+	<li><a href="/blog/archives/">Archive</a></li>
+	<li><a href="/about/">About me</a></li>
 </ul>
 
 </nav>


### PR DESCRIPTION
In chrome at least, navigating to a page sometimes momentarily shows a "not found" message while 301ing - there's no real need for the 301s if you add the trailing slash.